### PR TITLE
Implement debounced validation and memory-aware LLM

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@ This document tracks implementation tasks, features, and enhancements.
 
  - [x] Create synthetic bug report dataset (complete vs incomplete)
 - [ ] Train TF.js / ONNX model for predictive validation
-- [ ] Add live prediction on field blur or debounce
+- [x] Add live prediction on field blur or debounce
 
 ## 💬 Gen AI Integration
 
@@ -22,7 +22,7 @@ This document tracks implementation tasks, features, and enhancements.
   - Vague “Steps to Reproduce”
   - Invalid or missing version number
   - Unclassified feedback type
-- [ ] Disable LLM if memory is below threshold
+- [x] Disable LLM if memory is below threshold
 - [ ] Create reusable prompt templates
 
 ## 🧩 Agent System
@@ -35,7 +35,7 @@ This document tracks implementation tasks, features, and enhancements.
 
 ## 🧪 Testing
 
-- [ ] Add test mode with mock predictions
+- [x] Add test mode with mock predictions
 - [ ] Memory limit simulation mode
 - [ ] Verify fallback to static rules on low-end devices
 

--- a/src/agents/InputWatcherAgent.ts
+++ b/src/agents/InputWatcherAgent.ts
@@ -5,22 +5,46 @@ export interface InputWatcherAgent {
   watch(element: HTMLElement, field: string): () => void
 }
 
-export function createInputWatcherAgent(): InputWatcherAgent {
+export function createInputWatcherAgent(delay = 300): InputWatcherAgent {
   const callbacks: InputCallback[] = []
+  const timers = new WeakMap<HTMLElement, ReturnType<typeof setTimeout>>()
+
   return {
     register(cb) {
       callbacks.push(cb)
     },
     watch(element, field) {
-      const handler = (e: Event) => {
-        const target = e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-        callbacks.forEach((cb) => cb(field, target.value))
+      const run = (value: string) => {
+        callbacks.forEach((cb) => cb(field, value))
       }
-      element.addEventListener('blur', handler)
-      element.addEventListener('input', handler)
+
+      const onInput = (e: Event) => {
+        const target = e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+        const existing = timers.get(element)
+        if (existing) clearTimeout(existing)
+        timers.set(
+          element,
+          setTimeout(() => {
+            run(target.value)
+          }, delay),
+        )
+      }
+
+      const onBlur = (e: Event) => {
+        const target = e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+        const existing = timers.get(element)
+        if (existing) clearTimeout(existing)
+        run(target.value)
+      }
+
+      element.addEventListener('input', onInput)
+      element.addEventListener('blur', onBlur)
+
       return () => {
-        element.removeEventListener('blur', handler)
-        element.removeEventListener('input', handler)
+        element.removeEventListener('input', onInput)
+        element.removeEventListener('blur', onBlur)
+        const t = timers.get(element)
+        if (t) clearTimeout(t)
       }
     },
   }

--- a/src/hooks/useFieldExplainer.ts
+++ b/src/hooks/useFieldExplainer.ts
@@ -20,11 +20,14 @@ export function useFieldExplainer(enabled = true) {
     if (enabled && hasEnoughMemory() && !llm && !loading.current) {
       loading.current = true
       loadLLM().then((m) => setLLM(m))
+    } else if ((!enabled || !hasEnoughMemory()) && llm) {
+      setLLM(null)
+      loading.current = false
     }
   }, [enabled, llm])
 
   return async (value: string) => {
-    if (!llm) return null
+    if (!llm || !hasEnoughMemory()) return null
     if (value.trim().length < 10) {
       return llm.explain(value)
     }

--- a/src/lib/ml/model.ts
+++ b/src/lib/ml/model.ts
@@ -1,4 +1,14 @@
 export async function loadModel() {
+  // Use a predictable mock when running in test mode
+  if (import.meta.env.VITE_TEST_MODE === 'true') {
+    return {
+      predict: (value: string) => {
+        void value
+        return 0.9
+      },
+    }
+  }
+
   // Placeholder: In a real app, you would load a TF.js model from /public/models
   await new Promise((resolve) => setTimeout(resolve, 100))
   return {


### PR DESCRIPTION
## Summary
- run predictive validation with debounce via `InputWatcherAgent`
- disable the field explainer when memory drops
- support mock ML model with `VITE_TEST_MODE`
- check off completed tasks in TODO

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68848d0a968083308732ea9cd0b6bf47