### PR TITLE
Fix service worker registration in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ npm run dev
 
 Open `http://localhost:5173` to try it out.
 
+The service worker is only registered in production builds. Run `npm run build`
+followed by `npm run preview` to test offline support.
+
 ### Training the ML model
 
 The repository includes a small Python script that trains a text

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-if ('serviceWorker' in navigator) {
+if (import.meta.env.PROD && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker
       .register('/sw.js')


### PR DESCRIPTION
## Summary
- register the service worker only in production builds
- document how to test offline support in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68849cb621d483309e48dfceec8fc1af