### PR TITLE
Increase PWA precache limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ npm run build
 ```
 
 The optimized site is written to `dist/` and includes a service worker for offline usage. Preview it locally with `npm run preview` and deploy the `dist` folder to any static host.
+If your bundle is larger than 2 MiB, adjust the Workbox caching limit in
+`vite.config.ts` using `workbox.maximumFileSizeToCacheInBytes` so the service
+worker can precache all assets.
 
 ## Sample Bug Reports
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,11 @@ import { VitePWA } from 'vite-plugin-pwa'
 export default defineConfig({
   plugins: [
     react(),
-    VitePWA({ registerType: 'autoUpdate' }),
+    VitePWA({
+      registerType: 'autoUpdate',
+      workbox: {
+        maximumFileSizeToCacheInBytes: 6 * 1024 * 1024, // allow caching up to 6MB
+      },
+    }),
   ],
 })


### PR DESCRIPTION
## Summary
- allow larger bundles to be cached by the service worker
- document how to tweak Workbox limit in the readme

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884a2aca0388330a55236b40b5fd55f