### PR TITLE
Improve WebLLM model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ FormBuddy is a demo bug reporting form that showcases in-browser machine learnin
 - **Predictive Validation** using a lightweight TensorFlow.js model
 - **Field Explanation** powered by a mocked WebLLM client with reusable prompt templates
 - **Memory Aware** – the LLM features are automatically disabled on devices with low memory (use `VITE_LOW_MEMORY=true` in development to simulate) and fall back to static hints
-- **WebLLM Support** – set `VITE_USE_WEBLLM=true` to load a TinyLlama model via WebLLM
+- **WebLLM Support** – set `VITE_USE_WEBLLM=true` to enable WebLLM. The model can
+  be changed with `VITE_WEBLLM_MODEL_ID` if you want to load a different
+  prebuilt model. By default it uses a TinyLlama variant.
 - **Debug Logging** – set `VITE_LOG_MODEL_IO=true` to print ML and LLM inputs and outputs to the console
 
 ## Bug Report Form Fields

--- a/src/lib/llm/index.ts
+++ b/src/lib/llm/index.ts
@@ -6,12 +6,18 @@ import {
 
 const useWebLLM = import.meta.env.VITE_USE_WEBLLM === 'true'
 const logIO = import.meta.env.VITE_LOG_MODEL_IO === 'true'
+// Allow overriding the model id so that consumers can choose any model
+// supported by their version of WebLLM. Default to a small model known to
+// exist in `prebuiltAppConfig`.
+const modelId =
+  import.meta.env.VITE_WEBLLM_MODEL_ID ||
+  'TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC'
 
 export async function loadLLM() {
   if (useWebLLM) {
     try {
       const { CreateMLCEngine } = await import('@mlc-ai/web-llm')
-      const engine = await CreateMLCEngine('TinyLlama-3B-Chat-q4f32_0')
+      const engine = await CreateMLCEngine(modelId)
       return {
         explain: async (field: string, text: string) => {
           let prompt: string


### PR DESCRIPTION
## Summary
- allow overriding the WebLLM model ID via `VITE_WEBLLM_MODEL_ID`
- document how to choose a different model

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884a41ac0788330bd9b99954d333433