### PR TITLE
Fix stale LLM handler in FieldExplainer

### DIFF
--- a/src/agents/FieldExplainerAgent.ts
+++ b/src/agents/FieldExplainerAgent.ts
@@ -2,14 +2,19 @@ export type Explainer = (field: string, value: string) => Promise<string | null>
 
 export interface FieldExplainerAgent {
   getExplanation(field: string, value: string): Promise<string | null>
+  setExplainer(fn: Explainer): void
 }
 
 export function createFieldExplainerAgent(
   explain: Explainer,
 ): FieldExplainerAgent {
+  let current = explain
   return {
     getExplanation(field, value) {
-      return explain(field, value)
+      return current(field, value)
+    },
+    setExplainer(fn) {
+      current = fn
     },
   }
 }

--- a/src/components/BugReportForm.tsx
+++ b/src/components/BugReportForm.tsx
@@ -36,6 +36,10 @@ export function BugReportForm() {
   const validator = useRef(createPredictiveValidatorAgent(predict))
   const explainer = useRef(createFieldExplainerAgent(explain))
   const memory = useRef(createMemoryManagerAgent())
+
+  useEffect(() => {
+    explainer.current.setExplainer(explain)
+  }, [explain])
   const advisor = useRef(
     createSubmissionAdvisorAgent([
       'fullName',


### PR DESCRIPTION
## Summary
- allow updating explainer function in `FieldExplainerAgent`
- refresh agent whenever `useFieldExplainer` returns a new function

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884b08d046483308c69e8ef6dc0b4a9