### PR TITLE
Improve LLM explanations

### DIFF
--- a/src/agents/FieldExplainerAgent.ts
+++ b/src/agents/FieldExplainerAgent.ts
@@ -1,20 +1,33 @@
-export type Explainer = (field: string, value: string) => Promise<string | null>
+export type Explainer = (
+  field: string,
+  value: string,
+  errorType: string | null,
+) => Promise<string | null>
 
 export interface FieldExplainerAgent {
-  getExplanation(field: string, value: string): Promise<string | null>
+  getExplanation(
+    field: string,
+    value: string,
+    errorType: string | null,
+  ): Promise<string | null>
   setExplainer(fn: Explainer): void
 }
 
-export function createFieldExplainerAgent(
-  explain: Explainer,
-): FieldExplainerAgent {
+export function createFieldExplainerAgent(explain: Explainer): FieldExplainerAgent {
   let current = explain
+  const cache = new Map<string, string>()
   return {
-    getExplanation(field, value) {
-      return current(field, value)
+    async getExplanation(field, value, errorType) {
+      const key = `${field}|${value}|${errorType ?? ''}`
+      const cached = cache.get(key)
+      if (cached) return cached
+      const out = await current(field, value, errorType)
+      if (out) cache.set(key, out)
+      return out
     },
     setExplainer(fn) {
       current = fn
+      cache.clear()
     },
   }
 }

--- a/src/agents/PredictiveValidatorAgent.ts
+++ b/src/agents/PredictiveValidatorAgent.ts
@@ -1,7 +1,9 @@
-export type Validator = (value: string) => Promise<number | null>
+import type { Prediction } from '../lib/ml/model'
+
+export type Validator = (value: string) => Promise<Prediction | null>
 
 export interface PredictiveValidatorAgent {
-  check(field: string, value: string): Promise<number | null>
+  check(field: string, value: string): Promise<Prediction | null>
 }
 
 export function createPredictiveValidatorAgent(validate: Validator): PredictiveValidatorAgent {

--- a/src/components/BugReportForm.tsx
+++ b/src/components/BugReportForm.tsx
@@ -54,11 +54,15 @@ export function BugReportForm() {
 
   useEffect(() => {
     const handle = async (field: string, value: string) => {
-      const score = await validator.current.check(field, value)
-      if (score) {
+      const result = await validator.current.check(field, value)
+      if (result) {
         let message = 'This field may be incomplete.'
         memory.current.checkMemory()
-        const ex = await explainer.current.getExplanation(field, value)
+        const ex = await explainer.current.getExplanation(
+          field,
+          value,
+          result.type,
+        )
         if (ex) message = ex
         setHints((h) => ({ ...h, [field]: message }))
       } else {

--- a/src/hooks/usePredictiveValidation.ts
+++ b/src/hooks/usePredictiveValidation.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react'
-import { loadModel, type Model } from '../lib/ml/model'
+import { loadModel, type Model, type Prediction } from '../lib/ml/model'
 
 export function usePredictiveValidation(enabled = true) {
   const modelRef = useRef<Model | null>(null)
@@ -17,10 +17,10 @@ export function usePredictiveValidation(enabled = true) {
     return loading.current
   }
 
-  return async (value: string) => {
+  return async (value: string): Promise<Prediction | null> => {
     const model = await getModel()
     if (!model) return null
-    const score = model.predict(value)
-    return score > 0.7 ? score : null
+    const result = model.predict(value)
+    return result.score > 0.7 ? result : null
   }
 }

--- a/src/lib/llm/index.ts
+++ b/src/lib/llm/index.ts
@@ -33,20 +33,26 @@ export async function loadLLM() {
       console.log('[LLM] System prompt:', systemPrompt)
 
       return {
-        explain: async (field: string, text: string) => {
+        explain: async (
+          field: string,
+          text: string,
+          errorType: string | null,
+        ) => {
           let prompt: string
           switch (field) {
             case 'steps':
-              prompt = stepsPrompt(text)
+              prompt = stepsPrompt(text, errorType ?? undefined)
               break
             case 'version':
-              prompt = versionPrompt(text)
+              prompt = versionPrompt(text, errorType ?? undefined)
               break
             case 'feedbackType':
-              prompt = feedbackTypePrompt(text)
+              prompt = feedbackTypePrompt(text, errorType ?? undefined)
               break
             default:
-              prompt = `Provide feedback about: "${text}"`
+              prompt = `Provide feedback about: "${text}"${
+                errorType ? ` The ML model flagged this as ${errorType}.` : ''
+              }`
           }
           
           console.log('[LLM] Generating explanation for field:', field, 'with prompt:', prompt)
@@ -63,7 +69,16 @@ export async function loadLLM() {
             reply.choices?.[0]?.message?.content ?? 'Could not generate suggestion.'
 
           if (logIO) {
-            console.log('[LLM] field:', field, 'input:', text, 'output:', out)
+            console.log(
+              '[LLM] field:',
+              field,
+              'input:',
+              text,
+              'type:',
+              errorType,
+              'output:',
+              out,
+            )
           }
           
           return out
@@ -76,23 +91,38 @@ export async function loadLLM() {
 
   await new Promise((resolve) => setTimeout(resolve, 100))
   return {
-    explain: async (field: string, text: string) => {
+    explain: async (
+      field: string,
+      text: string,
+      errorType: string | null,
+    ) => {
       let out: string
       switch (field) {
         case 'steps':
-          out = stepsPrompt(text)
+          out = stepsPrompt(text, errorType ?? undefined)
           break
         case 'version':
-          out = versionPrompt(text)
+          out = versionPrompt(text, errorType ?? undefined)
           break
         case 'feedbackType':
-          out = feedbackTypePrompt(text)
+          out = feedbackTypePrompt(text, errorType ?? undefined)
           break
         default:
-          out = `Improve: "${text}"`
+          out = `Improve: "${text}"${
+            errorType ? ` The ML model flagged this as ${errorType}.` : ''
+          }`
       }
       if (logIO) {
-        console.log('[LLM] field:', field, 'input:', text, 'output:', out)
+        console.log(
+          '[LLM] field:',
+          field,
+          'input:',
+          text,
+          'type:',
+          errorType,
+          'output:',
+          out,
+        )
       }
       return out
     },

--- a/src/lib/llm/prompts.ts
+++ b/src/lib/llm/prompts.ts
@@ -1,11 +1,17 @@
-export function stepsPrompt(text: string) {
-  return `Suggest clearer reproduction steps for: "${text}"`
+export function stepsPrompt(text: string, reason?: string) {
+  return `The user wrote "${text}" in the Steps to Reproduce field.${
+    reason ? ` The ML model flagged this as ${reason}.` : ''
+  } Suggest clearer, step-by-step instructions.`
 }
 
-export function versionPrompt(text: string) {
-  return `Give a hint about providing a valid version instead of "${text}"`
+export function versionPrompt(text: string, reason?: string) {
+  return `The user entered "${text}" as the app version.${
+    reason ? ` The ML model flagged this as ${reason}.` : ''
+  } Suggest a valid semantic version like 1.2.3.`
 }
 
-export function feedbackTypePrompt(text: string) {
-  return `Help the user pick a feedback type when they entered "${text}"`
+export function feedbackTypePrompt(text: string, reason?: string) {
+  return `The user chose "${text}" for feedback type.${
+    reason ? ` The ML model flagged this as ${reason}.` : ''
+  } Suggest one of: Bug, Feature, or UI Issue.`
 }

--- a/src/lib/ml/model.ts
+++ b/src/lib/ml/model.ts
@@ -1,16 +1,21 @@
 const logIO = import.meta.env.VITE_LOG_MODEL_IO === 'true'
 
+export interface Prediction {
+  score: number
+  type: string
+}
+
 export async function loadModel() {
   // Use a predictable mock when running in test mode
   if (import.meta.env.VITE_TEST_MODE === 'true') {
     return {
-      predict: (value: string) => {
+      predict: (value: string): Prediction => {
         void value
-        const score = 0.9
+        const result = { score: 0.9, type: 'incomplete' } as Prediction
         if (logIO) {
-          console.log('[ML] input:', value, 'score:', score)
+          console.log('[ML] input:', value, 'score:', result.score, 'type:', result.type)
         }
-        return score
+        return result
       },
     }
   }
@@ -18,13 +23,24 @@ export async function loadModel() {
   // Placeholder: In a real app, you would load a TF.js model from /public/models
   await new Promise((resolve) => setTimeout(resolve, 100))
   return {
-    predict: (input: string) => {
-      // Very naive heuristic: flag short or empty input as problematic
-      const score = input.trim().length < 10 ? 0.8 : 0.2
-      if (logIO) {
-        console.log('[ML] input:', input, 'score:', score)
+    predict: (input: string): Prediction => {
+      const trimmed = input.trim()
+      let score: number
+      let type: string
+      if (!trimmed) {
+        score = 0.9
+        type = 'missing'
+      } else if (trimmed.length < 10) {
+        score = 0.8
+        type = 'too short'
+      } else {
+        score = 0.2
+        type = 'ok'
       }
-      return score
+      if (logIO) {
+        console.log('[ML] input:', input, 'score:', score, 'type:', type)
+      }
+      return { score, type }
     },
   }
 }


### PR DESCRIPTION
## Summary
- include ML prediction type in prompts
- cache LLM suggestions to avoid repeated calls
- extend predictive validation to report error type
- provide error type to explanation agent and form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884b4d8a55c8330a3027b82e1cdca28