### PR TITLE
Fix InputWatcher invalid target handling

### DIFF
--- a/src/agents/InputWatcherAgent.ts
+++ b/src/agents/InputWatcherAgent.ts
@@ -2,18 +2,27 @@ export type InputCallback = (field: string, value: string) => void
 
 export interface InputWatcherAgent {
   register(cb: InputCallback): void
-  watch(element: HTMLElement, field: string): () => void
+  watch(element: EventTarget | null, field: string): () => void
+}
+
+function isEventTarget(el: unknown): el is EventTarget {
+  return !!el && typeof (el as EventTarget).addEventListener === 'function'
 }
 
 export function createInputWatcherAgent(delay = 300): InputWatcherAgent {
   const callbacks: InputCallback[] = []
-  const timers = new WeakMap<HTMLElement, ReturnType<typeof setTimeout>>()
+  const timers = new WeakMap<EventTarget, ReturnType<typeof setTimeout>>()
 
   return {
     register(cb) {
       callbacks.push(cb)
     },
     watch(element, field) {
+      if (!isEventTarget(element)) {
+        console.warn('InputWatcherAgent.watch: invalid element', element)
+        return () => {}
+      }
+
       const run = (value: string) => {
         callbacks.forEach((cb) => cb(field, value))
       }

--- a/src/components/BugReportForm.tsx
+++ b/src/components/BugReportForm.tsx
@@ -112,8 +112,12 @@ export function BugReportForm() {
       [actualRef, 'actual'],
     ]
     const cleanups = refs
-      .filter(([r]) => r.current)
-      .map(([r, field]) => watcher.current.watch(r.current!, field))
+      .map(([r, field]) => {
+        const el = r.current
+        return el && 'addEventListener' in el
+          ? watcher.current.watch(el, field)
+          : () => {}
+      })
     return () => {
       cleanups.forEach((c) => c())
     }


### PR DESCRIPTION
## Summary
- ensure InputWatcherAgent verifies the target before attaching listeners
- guard BugReportForm watcher setup to skip invalid refs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884c0a1f6888330a944a8aa1d5fef60