### PR TITLE
Add useFormBuddy helper hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -9,3 +9,6 @@ Set `VITE_LOG_MODEL_IO=true` to log model inputs and outputs for debugging.
 ## `useFieldExplainer`
 Loads a browser friendly LLM and returns an async function that can provide a short explanation for vague input. The hook checks memory limits before loading the model. Set `VITE_LOW_MEMORY=true` to simulate a low-memory environment during development.
 `VITE_LOG_MODEL_IO=true` will also log explanation prompts and responses.
+
+## `useFormBuddy`
+Combines the predictive validator and field explainer into one helper. Pass the form description and an array of field details. It returns an `onBlur` callback and a `loading` flag. Call the callback with the field name and value from your input's `onBlur` handler. The hook loads the ONNX model and WebLLM engine in parallel and updates the RHF error state with any generated message. Results are cached by `field|value` to avoid duplicate LLM calls.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ python scripts/train_model.py
 - `src/components/BugReportForm.tsx` – main form component
 - `src/hooks/usePredictiveValidation.ts` – loads and runs the ML model
 - `src/hooks/useFieldExplainer.ts` – loads the LLM and provides text suggestions
+- `src/hooks/useFormBuddy.ts` – high level helper that ties everything together
 - `src/lib/ml/model.ts` – placeholder ML implementation
 - `src/lib/llm/index.ts` – mock LLM client
 - `public/models` – place to store local model files

--- a/src/components/BugReportForm.tsx
+++ b/src/components/BugReportForm.tsx
@@ -1,24 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import {
-  Box,
-  Button,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  Stack,
-  TextField,
-} from '@mui/material'
-import { usePredictiveValidation } from '../hooks/usePredictiveValidation'
-import { useFieldExplainer } from '../hooks/useFieldExplainer'
-import {
-  createInputWatcherAgent,
-  createPredictiveValidatorAgent,
-  createFieldExplainerAgent,
-  createMemoryManagerAgent,
-  createSubmissionAdvisorAgent,
-} from '../agents'
+import { Box, Button, FormControl, InputLabel, MenuItem, Select, Stack, TextField } from '@mui/material'
+import { FormProvider, useForm, useFormContext } from 'react-hook-form'
+import { useFormBuddy, type FieldDetail } from '../hooks/useFormBuddy'
 
 interface FormValues {
   fullName: string
@@ -31,141 +13,45 @@ interface FormValues {
   screenshot?: FileList
 }
 
-export function BugReportForm() {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<FormValues>()
+const FORM_DESCRIPTION = 'Bug report submission form for the FormBuddy demo application.'
 
-  const predict = usePredictiveValidation(true)
-  const explain = useFieldExplainer(true)
-  const [hints, setHints] = useState<Record<string, string>>({})
-  const [checking, setChecking] = useState<Record<string, boolean>>({})
+const FIELDS: FieldDetail[] = [
+  { name: 'fullName', description: 'Your full name' },
+  { name: 'email', description: 'Contact email address' },
+  { name: 'feedbackType', description: 'Bug, Feature or UI Issue' },
+  { name: 'version', description: 'Application version number' },
+  { name: 'steps', description: 'Steps to reproduce the problem' },
+  { name: 'expected', description: 'Expected behaviour of the application' },
+  { name: 'actual', description: 'Actual behaviour observed' },
+]
 
-  const watcher = useRef(createInputWatcherAgent())
-  const validator = useRef(createPredictiveValidatorAgent(predict))
-  const explainer = useRef(createFieldExplainerAgent(explain))
-  const memory = useRef(createMemoryManagerAgent())
-
-  useEffect(() => {
-    explainer.current.setExplainer(explain)
-  }, [explain])
-  const advisor = useRef(
-    createSubmissionAdvisorAgent([
-      'fullName',
-      'email',
-      'feedbackType',
-      'version',
-      'steps',
-      'expected',
-      'actual',
-    ])
-  )
-
-  useEffect(() => {
-    const handle = async (field: string, value: string) => {
-      setChecking((c) => ({ ...c, [field]: true }))
-      const result = await validator.current.check(field, value)
-      if (result) {
-        let message = 'This field may be incomplete.'
-        memory.current.checkMemory()
-        const ex = await explainer.current.getExplanation(
-          field,
-          value,
-          result.type,
-        )
-        if (ex) message = ex
-        setHints((h) => ({ ...h, [field]: message }))
-      } else {
-        setHints((h) => ({ ...h, [field]: '' }))
-      }
-      setChecking((c) => ({ ...c, [field]: false }))
-    }
-    watcher.current.register(handle)
-  }, [])
+function InnerForm() {
+  const { register, handleSubmit, formState: { errors } } = useFormContext<FormValues>()
+  const { handleBlur, loading } = useFormBuddy<FormValues>(FORM_DESCRIPTION, FIELDS)
 
   const onSubmit = (data: FormValues) => {
-    if (advisor.current.canSubmit(hints)) {
-      alert(JSON.stringify(data, null, 2))
-    } else {
-      alert('Please fix the highlighted issues before submitting.')
-    }
+    alert(JSON.stringify(data, null, 2))
   }
-
-  const fullNameRef = useRef<HTMLInputElement | null>(null)
-  const emailRef = useRef<HTMLInputElement | null>(null)
-  const feedbackTypeRef = useRef<HTMLSelectElement | null>(null)
-  const versionRef = useRef<HTMLInputElement | null>(null)
-  const stepsRef = useRef<HTMLTextAreaElement | null>(null)
-  const expectedRef = useRef<HTMLTextAreaElement | null>(null)
-  const actualRef = useRef<HTMLTextAreaElement | null>(null)
-
-  useEffect(() => {
-    const refs: [React.RefObject<HTMLElement | null>, keyof FormValues][] = [
-      [fullNameRef, 'fullName'],
-      [emailRef, 'email'],
-      [feedbackTypeRef, 'feedbackType'],
-      [versionRef, 'version'],
-      [stepsRef, 'steps'],
-      [expectedRef, 'expected'],
-      [actualRef, 'actual'],
-    ]
-    const cleanups = refs
-      .map(([r, field]) => {
-        const el = r.current
-        return el && 'addEventListener' in el
-          ? watcher.current.watch(el, field)
-          : () => {}
-      })
-    return () => {
-      cleanups.forEach((c) => c())
-    }
-  }, [])
-
-  const {
-    ref: fullNameRegRef,
-    ...fullNameRest
-  } = register('fullName', { required: true })
-  const { ref: emailRegRef, ...emailRest } = register('email', { required: true })
-  const { ref: feedbackRegRef, ...feedbackRest } = register('feedbackType', { required: true })
-  const { ref: versionRegRef, ...versionRest } = register('version', { required: true })
-  const { ref: stepsRegRef, ...stepsRest } = register('steps', { required: true })
-  const { ref: expectedRegRef, ...expectedRest } = register('expected', { required: true })
-  const { ref: actualRegRef, ...actualRest } = register('actual', { required: true })
 
   return (
     <Box component="form" onSubmit={handleSubmit(onSubmit)} noValidate>
+      {loading && <small>Initializing assistant...</small>}
       <Stack spacing={2}>
         <TextField
           label="Full Name"
-          {...fullNameRest}
-          inputRef={(el) => {
-            fullNameRef.current = el
-            fullNameRegRef(el)
-          }}
+          {...register('fullName', { required: 'Required' })}
+          onBlur={(e) => handleBlur('fullName', e.target.value)}
           error={!!errors.fullName}
-          helperText={
-            checking.fullName
-              ? 'Checking...'
-              : errors.fullName
-                ? 'Required'
-                : hints.fullName || ' '
-          }
+          helperText={errors.fullName?.message || ' '}
         />
 
         <TextField
           label="Email"
           type="email"
-          {...emailRest}
-          inputRef={(el) => {
-            emailRef.current = el
-            emailRegRef(el)
-          }}
+          {...register('email', { required: 'Required' })}
+          onBlur={(e) => handleBlur('email', e.target.value)}
           error={!!errors.email}
-          helperText={
-            checking.email ? 'Checking...' : errors.email ? 'Required' : hints.email || ' '
-          }
+          helperText={errors.email?.message || ' '}
         />
 
         <FormControl fullWidth error={!!errors.feedbackType}>
@@ -173,87 +59,53 @@ export function BugReportForm() {
           <Select
             labelId="feedback-type-label"
             label="Feedback Type"
-            {...feedbackRest}
-            inputRef={(el) => {
-              feedbackTypeRef.current = el
-              feedbackRegRef(el)
-            }}
+            defaultValue="Bug"
+            {...register('feedbackType', { required: 'Required' })}
+            onBlur={(e) => handleBlur('feedbackType', (e.target as HTMLInputElement).value)}
           >
             <MenuItem value="Bug">Bug</MenuItem>
             <MenuItem value="Feature">Feature</MenuItem>
             <MenuItem value="UI Issue">UI Issue</MenuItem>
           </Select>
-          {errors.feedbackType || hints.feedbackType ? (
-            <small>
-              {checking.feedbackType
-                ? 'Checking...'
-                : errors.feedbackType
-                  ? 'Required'
-                  : hints.feedbackType}
-            </small>
-          ) : null}
+          <small>{errors.feedbackType?.message || ' '}</small>
         </FormControl>
 
         <TextField
           label="App Version"
-          {...versionRest}
-          inputRef={(el) => {
-            versionRef.current = el
-            versionRegRef(el)
-          }}
+          {...register('version', { required: 'Required' })}
+          onBlur={(e) => handleBlur('version', e.target.value)}
           error={!!errors.version}
-          helperText={
-            checking.version ? 'Checking...' : errors.version ? 'Required' : hints.version || ' '
-          }
+          helperText={errors.version?.message || ' '}
         />
 
         <TextField
           label="Steps to Reproduce"
           multiline
           minRows={3}
-          {...stepsRest}
-          inputRef={(el) => {
-            stepsRef.current = el
-            stepsRegRef(el)
-          }}
+          {...register('steps', { required: 'Required' })}
+          onBlur={(e) => handleBlur('steps', e.target.value)}
           error={!!errors.steps}
-          helperText={
-            checking.steps ? 'Checking...' : errors.steps ? 'Required' : hints.steps || ' '
-          }
+          helperText={errors.steps?.message || ' '}
         />
 
         <TextField
           label="Expected Behavior"
           multiline
           minRows={2}
-          {...expectedRest}
-          inputRef={(el) => {
-            expectedRef.current = el
-            expectedRegRef(el)
-          }}
+          {...register('expected', { required: 'Required' })}
+          onBlur={(e) => handleBlur('expected', e.target.value)}
           error={!!errors.expected}
-          helperText={
-            checking.expected
-              ? 'Checking...'
-              : errors.expected
-                ? 'Required'
-                : hints.expected || ' '
-          }
+          helperText={errors.expected?.message || ' '}
         />
 
         <TextField
           label="Actual Behavior"
           multiline
           minRows={2}
-          {...actualRest}
-          inputRef={(el) => {
-            actualRef.current = el
-            actualRegRef(el)
-          }}
+          {...register('actual', { required: 'Required' })}
+          onBlur={(e) => handleBlur('actual', e.target.value)}
           error={!!errors.actual}
-          helperText={
-            checking.actual ? 'Checking...' : errors.actual ? 'Required' : hints.actual || ' '
-          }
+          helperText={errors.actual?.message || ' '}
         />
 
         <Button variant="outlined" component="label">
@@ -268,4 +120,15 @@ export function BugReportForm() {
     </Box>
   )
 }
+
+export function BugReportForm() {
+  const methods = useForm<FormValues>()
+
+  return (
+    <FormProvider {...methods}>
+      <InnerForm />
+    </FormProvider>
+  )
+}
+
 export default BugReportForm

--- a/src/hooks/useFormBuddy.ts
+++ b/src/hooks/useFormBuddy.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react'
+import { useFormContext, type FieldValues, type Path } from 'react-hook-form'
+import { loadModel, type Model, type Prediction } from '../lib/ml/model'
+import { loadLLM, type LLM } from '../lib/llm'
+
+export interface FieldDetail {
+  name: string
+  description: string
+}
+
+export function useFormBuddy<T extends FieldValues>(
+  formDescription: string,
+  fields: FieldDetail[],
+) {
+  const { setError } = useFormContext<T>()
+  const [loading, setLoading] = useState(true)
+  const modelRef = useRef<Model | null>(null)
+  const llmRef = useRef<LLM | null>(null)
+  const cache = useRef(new Map<string, string>())
+  const fieldMap = useRef<Record<string, string>>(
+    Object.fromEntries(fields.map((f) => [f.name, f.description])),
+  )
+
+  useEffect(() => {
+    let canceled = false
+    Promise.all([loadModel(), loadLLM()]).then(([model, llm]) => {
+      if (!canceled) {
+        modelRef.current = model
+        llmRef.current = llm
+        setLoading(false)
+      }
+    })
+    return () => {
+      canceled = true
+    }
+  }, [])
+
+  const handleBlur = async (name: Path<T>, value: string) => {
+    if (!modelRef.current || !llmRef.current) return
+    const key = `${name}|${value}`
+    const cached = cache.current.get(key)
+    if (cached) {
+      setError(name, { type: 'formbuddy', message: cached })
+      return
+    }
+    const prediction: Prediction = modelRef.current.predict(value)
+    if (prediction.score > 0.7) {
+      const fieldDesc = fieldMap.current[name] || ''
+      const text = `${value}\n\nForm: ${formDescription}\nField: ${fieldDesc}`
+      const message = await llmRef.current.explain(
+        name,
+        text,
+        prediction.type,
+      )
+      if (message) {
+        cache.current.set(key, message)
+        setError(name, { type: 'formbuddy', message })
+      }
+    }
+  }
+
+  return { handleBlur, loading }
+}


### PR DESCRIPTION
## Summary
- implement a new hook `useFormBuddy` that wraps predictive validation and field explainer
- document new hook in `HOOKS.md` and README
- simplify `BugReportForm` by using `useFormBuddy`

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.app.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6884c3997a0083308bb2644edf5a9cf5