### PR TITLE
Add model names and dynamic system prompts

### DIFF
--- a/src/components/BugReportForm.tsx
+++ b/src/components/BugReportForm.tsx
@@ -3,6 +3,7 @@ import { FormProvider, useForm, useFormContext } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import { useFormBuddy, type FieldDetail } from '../hooks/useFormBuddy'
+import { defaultSystemPrompts } from '../lib/llm/systemPrompts'
 
 interface FormValues {
   fullName: string
@@ -46,7 +47,11 @@ const schema: yup.ObjectSchema<FormValues> = yup.object({
 
 function InnerForm() {
   const { register, handleSubmit, trigger, formState: { errors } } = useFormContext<FormValues>()
-  const { handleBlur, loading, checking } = useFormBuddy<FormValues>(FORM_DESCRIPTION, FIELDS)
+  const { handleBlur, loading, checking } = useFormBuddy<FormValues>(
+    FORM_DESCRIPTION,
+    FIELDS,
+    defaultSystemPrompts,
+  )
 
   const fullNameField = register('fullName')
   const emailField = register('email')

--- a/src/lib/llm/index.ts
+++ b/src/lib/llm/index.ts
@@ -12,7 +12,7 @@ const useWebLLM = import.meta.env.VITE_USE_WEBLLM === 'true'
 const logIO = import.meta.env.VITE_LOG_MODEL_IO === 'true'
 
 const modelId = import.meta.env.VITE_WEBLLM_MODEL_ID || 'Qwen3-1.7B-q4f32_1-MLC'
-const systemPrompt =
+const defaultSystemPrompt =
   'You are a concise assistant helping users correct and improve short form inputs for a bug report. Avoid long explanations. Reply in under two sentences using clear, direct language.'
 
 export async function loadLLM() {
@@ -22,13 +22,15 @@ export async function loadLLM() {
       const engine = await CreateMLCEngine(modelId)
 
       console.log('[LLM] Active model:', modelId)
-      console.log('[LLM] System prompt:', systemPrompt)
+      console.log('[LLM] System prompt:', defaultSystemPrompt)
 
       return {
+        modelName: modelId,
         explain: async (
           field: string,
           text: string,
           errorType: string | null,
+          systemPrompt: string = defaultSystemPrompt,
         ) => {
           let prompt: string
           switch (field) {
@@ -83,11 +85,14 @@ export async function loadLLM() {
 
   await new Promise((resolve) => setTimeout(resolve, 100))
   return {
+    modelName: modelId,
     explain: async (
       field: string,
       text: string,
       errorType: string | null,
+      systemPrompt: string = defaultSystemPrompt,
     ) => {
+      void systemPrompt
       let out: string
       switch (field) {
         case 'steps':

--- a/src/lib/llm/systemPrompts.ts
+++ b/src/lib/llm/systemPrompts.ts
@@ -1,0 +1,15 @@
+export type SystemPromptFn = (
+  formDescription: string,
+  fieldName: string,
+) => string
+
+export type SystemPromptMap = Record<string, SystemPromptFn>
+
+export const defaultSystemPrompts: SystemPromptMap = {
+  missing: (form, field) =>
+    `You are a concise assistant helping users fill out the "${form}" form. The field "${field}" is missing details. Provide short guidance.`,
+  "too short": (form, field) =>
+    `You are a concise assistant for the "${form}" form. Encourage the user to add more detail to "${field}".`,
+  default: (form, field) =>
+    `You are a concise assistant helping users correct and improve the "${field}" field in the "${form}" form.`,
+}

--- a/src/lib/ml/model.ts
+++ b/src/lib/ml/model.ts
@@ -5,10 +5,13 @@ export interface Prediction {
   type: string
 }
 
+const modelName = 'bug_report_classifier.onnx'
+
 export async function loadModel() {
   // Use a predictable mock when running in test mode
   if (import.meta.env.VITE_TEST_MODE === 'true') {
     return {
+      modelName,
       predict: (value: string): Prediction => {
         void value
         const result = { score: 0.9, type: 'incomplete' } as Prediction
@@ -23,6 +26,7 @@ export async function loadModel() {
   // Placeholder: In a real app, you would load a TF.js model from /public/models
   await new Promise((resolve) => setTimeout(resolve, 100))
   return {
+    modelName,
     predict: (input: string): Prediction => {
       const trimmed = input.trim()
       let score: number


### PR DESCRIPTION
## Summary
- include ML model name and LLM model name in the `useFormBuddy` hook
- allow `useFormBuddy` to accept a map of error codes to system prompts
- implement default prompt map in a new `systemPrompts` module
- expose model names from ml and llm loaders
- wire up bug report form to provide the default prompt map

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884c9d5641483309670b557d920291e