### PR TITLE
Fix training script for new dataset format

### DIFF
--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -30,12 +30,19 @@ def load_data():
     texts = []
     labels = []
     for entry in data:
-        errors = entry.get("errors", {})
-        for field in FIELDS:
-            value = entry.get(field, "")
-            label = errors.get(field, "ok")
-            texts.append(f"{field}: {value}")
-            labels.append(label)
+        errors = entry.get("errors")
+        if errors:
+            for field in FIELDS:
+                value = entry.get(field, "")
+                label = errors.get(field, "ok")
+                texts.append(f"{field}: {value}")
+                labels.append(label)
+        else:
+            label = entry.get("label", "ok")
+            for field in FIELDS:
+                value = entry.get(field, "")
+                texts.append(f"{field}: {value}")
+                labels.append(label)
     return texts, labels
 
 


### PR DESCRIPTION
## Summary
- handle bug report datasets without `errors` by falling back to entry label

## Testing
- `npm run lint`
- `npm run build`
- `python scripts/train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6884d03f144483308bd8d28967cab25c