### PR TITLE
Fix npm workspace dependency

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "form-buddy": "workspace:*",
+    "form-buddy": "file:../form-buddy",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@hookform/resolvers": "^5.2.0",


### PR DESCRIPTION
## Summary
- fix workspace install error by using `file:` reference

## Testing
- `npm run -w packages/example lint`
- `npm i`

------
https://chatgpt.com/codex/tasks/task_e_6884d82675d883308ac749ab2739e9e4