### PR TITLE
Refactor prompts and classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,10 @@ When a field looks incomplete, the predictive model flags it and the field expla
 
 3. **Train the classifier.** Run `python training/train_model.py` to produce an ONNX model. The script reads the dataset, trains a logistic regression pipeline and writes `bug_report_classifier.onnx` to `packages/example/public/models`.
 
-4. **Define system prompts.** Prompts are generated dynamically based on form description, field description and the ML error type. The example application defines a helper:
+4. **Define system prompts.** Prompts are generated dynamically based on form description, field description and the ML error type. The example simply reuses the default generator:
 
    ```ts
-   const getPrompt = (form: string, field: string, error: string) => {
-     switch (error) {
-       case 'missing':
-         return `You are assisting with the "${form}" form. The field "${field}" is missing information. Provide a short suggestion.`
-       case 'invalid':
-         return `You are assisting with the "${form}" form. The field "${field}" looks invalid. Explain briefly how to fix it.`
-       default:
-         return defaultPromptGenerator(form, field, error)
-     }
-   }
+   const getPrompt = defaultPromptGenerator
    ```
 
 5. **Use the hook.** Call `useFormBuddy` inside your form component:
@@ -92,6 +83,7 @@ When a field looks incomplete, the predictive model flags it and the field expla
    const { handleBlur } = useFormBuddy(FORM_DESCRIPTION, FIELDS, getPrompt, {
      validationModelName: 'bug_report_classifier.onnx',
      llmModelName: import.meta.env.VITE_WEBLLM_MODEL_ID,
+     errorTypes: ['missing', 'too short', 'ok'],
    })
    ```
 

--- a/packages/example/src/components/BugReportForm.tsx
+++ b/packages/example/src/components/BugReportForm.tsx
@@ -30,20 +30,7 @@ const FIELDS: FieldDetail[] = [
 ]
 
 // Function to generate prompts for form-buddy based on field errors
-const getPrompt = (
-  form: string,
-  field: string,
-  error: string,
-) => {
-  switch (error) {
-    case 'missing':
-      return `You are assisting with the "${form}" form. The field "${field}" is missing information. Provide a short suggestion.`
-    case 'invalid':
-      return `You are assisting with the "${form}" form. The field "${field}" looks invalid. Explain briefly how to fix it.`
-    default:
-      return defaultPromptGenerator(form, field, error)
-  }
-}
+const getPrompt = defaultPromptGenerator
 
 // Validation schema using Yup
 const schema: yup.ObjectSchema<FormValues> = yup.object({
@@ -73,6 +60,7 @@ function InnerForm() {
       validationModelName: 'bug_report_classifier.onnx',
       llmModelName: 'Qwen3-1.7B-q4f32_1-MLC',
       threshold: 0.7,
+      errorTypes: ['missing', 'too short', 'ok'],
     },
   )
 

--- a/packages/form-buddy/HOOKS.md
+++ b/packages/form-buddy/HOOKS.md
@@ -16,3 +16,4 @@ The options object supports:
 - `validationModelName` – ONNX model file to load
 - `llmModelName` – WebLLM model identifier
 - `threshold` – confidence score required to trigger the explainer
+- `errorTypes` – list of possible error labels returned by the ML model

--- a/packages/form-buddy/src/lib/llm.ts
+++ b/packages/form-buddy/src/lib/llm.ts
@@ -7,7 +7,7 @@ const logIO = import.meta.env.VITE_LOG_MODEL_IO === 'true'
 
 const envModelId = import.meta.env.VITE_WEBLLM_MODEL_ID || 'Qwen3-1.7B-q4f32_1-MLC'
 const defaultSystemPrompt =
-  'You are a concise assistant helping users correct and improve short form inputs for a bug report. Avoid long explanations.'
+  'You are Qwen, an efficient assistant for improving bug report form fields. Provide one short, actionable suggestion.'
 
 export async function loadLLM(id: string = envModelId) {
   if (useWebLLM) {

--- a/packages/form-buddy/src/prompts.ts
+++ b/packages/form-buddy/src/prompts.ts
@@ -1,20 +1,4 @@
-export function stepsPrompt(text: string, reason?: string) {
-  return `The user wrote "${text}" in the Steps to Reproduce field.${
-    reason ? ` The ML model flagged this as ${reason}.` : ''
-  } Suggest clearer, step-by-step instructions.`
-}
 
-export function versionPrompt(text: string, reason?: string) {
-  return `The user entered "${text}" as the app version.${
-    reason ? ` The ML model flagged this as ${reason}.` : ''
-  } Suggest a valid semantic version like 1.2.3.`
-}
-
-export function feedbackTypePrompt(text: string, reason?: string) {
-  return `The user chose "${text}" for feedback type.${
-    reason ? ` The ML model flagged this as ${reason}.` : ''
-  } Suggest one of: Bug, Feature, or UI Issue.`
-}
 
 export type SystemPromptGenerator = (
   formDescription: string,
@@ -26,13 +10,5 @@ export const defaultPromptGenerator: SystemPromptGenerator = (
   form,
   field,
   error,
-) => {
-  switch (error) {
-    case 'missing':
-      return `You are a concise assistant helping users fill out the "${form}" form. The field "${field}" is missing details. Provide short guidance in one sentence.`
-    case 'too short':
-      return `You are a concise assistant for the "${form}" form. Encourage the user to add more detail to "${field}" in one short sentence.`
-    default:
-      return `You are a concise assistant helping users correct and improve the "${field}" field in the "${form}" form. Reply in one short sentence.`
-  }
-}
+) =>
+  `You are Qwen, an efficient assistant for the "${form}" form. The field "${field}" was flagged as "${error}" by a classifier. Provide one short, actionable suggestion.`


### PR DESCRIPTION
## Summary
- simplify prompt generation
- use a Qwen-optimized system prompt
- allow custom error labels in the ML classifier and hook
- update docs and example usage

## Testing
- `npm --workspace packages/example run lint`
- `npm --workspace packages/example run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6884e2102a1c8330b5aa04af871ee73a