### PR TITLE
Improve fallback prompts

### DIFF
--- a/packages/example/src/components/BugReportForm.tsx
+++ b/packages/example/src/components/BugReportForm.tsx
@@ -29,17 +29,20 @@ const FIELDS: FieldDetail[] = [
   { name: 'actual', description: 'Actual behaviour observed' },
 ]
 
-// Function to generate prompts for form-buddy based on field errors
+// Generate more detailed prompts based on the detected error type
 const getPrompt = (
   form: string,
   field: string,
   error: string,
 ) => {
+  const base = `You are assisting with the "${form}" form.`
   switch (error) {
     case 'missing':
-      return `You are assisting with the "${form}" form. The field "${field}" is missing information. Provide a short suggestion.`
+      return `${base} The user left the "${field}" field empty. Explain in one sentence what information should be provided.`
     case 'invalid':
-      return `You are assisting with the "${form}" form. The field "${field}" looks invalid. Explain briefly how to fix it.`
+      return `${base} The value for "${field}" looks invalid. Give a brief example of a valid entry.`
+    case 'too short':
+      return `${base} The input in "${field}" is too short. Suggest how to make it more descriptive.`
     default:
       return defaultPromptGenerator(form, field, error)
   }

--- a/packages/form-buddy/src/lib/llm.ts
+++ b/packages/form-buddy/src/lib/llm.ts
@@ -55,7 +55,27 @@ export async function loadLLM(id: string = envModelId) {
       systemPrompt: string = defaultSystemPrompt,
     ) => {
       void systemPrompt
-      const out = `Improve: "${prompt}"`
+      // Simple heuristic fallback when WebLLM is disabled
+      const reasonMatch = prompt.match(/Reason:\s*(.+)/)
+      const fieldMatch = prompt.match(/Field:\s*(.+)/)
+      const reason = reasonMatch ? reasonMatch[1].toLowerCase() : ''
+      const field = fieldMatch ? fieldMatch[1].toLowerCase() : 'field'
+
+      let out: string
+      switch (reason) {
+        case 'missing':
+          out = `Please fill in the ${field}.`
+          break
+        case 'too short':
+          out = `Provide a more detailed ${field}.`
+          break
+        case 'invalid':
+          out = `The ${field} seems invalid. Please correct it.`
+          break
+        default:
+          out = `Consider improving the ${field}.`
+      }
+
       if (logIO) {
         console.log('[LLM] input:', prompt, 'output:', out)
       }


### PR DESCRIPTION
## Summary
- refine example BugReportForm prompt generator for better suggestions

## Testing
- `npm --workspace packages/example run lint`
- `npm --workspace packages/example run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6884e6e8c1d083309c72c70a79fd6f90