### PR TITLE
Sort error labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ FormBuddy is proof that modern browsers aren’t just Chrome—they’re Chrome 
    const { handleBlur } = useFormBuddy(FORM_DESCRIPTION, FIELDS, getPrompt, {
      validationModelName: 'bug_report_classifier.onnx',
      llmModelName: import.meta.env.VITE_WEBLLM_MODEL_ID,
-     errorTypes: ['missing', 'too short', 'ok'],
+     errorTypes: ['missing', 'too short', 'ok'], // will be alphabetically sorted
    })
    ```
 

--- a/packages/form-buddy/HOOKS.md
+++ b/packages/form-buddy/HOOKS.md
@@ -16,4 +16,6 @@ The options object supports:
 - `validationModelName` – ONNX model file to load
 - `llmModelName` – WebLLM model identifier
 - `threshold` – confidence score required to trigger the explainer
-- `errorTypes` – list of possible error labels returned by the ML model
+- `errorTypes` – list of possible error labels returned by the ML model.
+  The array is sorted alphabetically before being passed to the predictor
+  to match the class order used when training.

--- a/packages/form-buddy/src/lib/classifier.ts
+++ b/packages/form-buddy/src/lib/classifier.ts
@@ -11,13 +11,15 @@ export async function loadModel(
   name: string = defaultModelName,
   errorTypes: string[] = ['missing', 'too short', 'ok'],
 ) {
+  // Ensure consistent ordering of labels used by the model
+  const orderedTypes = [...errorTypes].sort()
   // Use a predictable mock when running in test mode
   if (import.meta.env.VITE_TEST_MODE === 'true') {
     return {
       modelName: name,
       predict: (value: string): Prediction => {
         void value
-        const result = { score: 0.9, type: errorTypes[0] || 'incomplete' } as Prediction
+        const result = { score: 0.9, type: orderedTypes[0] || 'incomplete' } as Prediction
         if (logIO) {
           console.log('[ML] input:', value, 'score:', result.score, 'type:', result.type)
         }
@@ -33,13 +35,13 @@ export async function loadModel(
     predict: (input: string): Prediction => {
       const trimmed = input.trim()
       let score: number
-      let type: string = errorTypes[errorTypes.length - 1] || 'ok'
-      if (!trimmed && errorTypes[0]) {
+      let type: string = orderedTypes[orderedTypes.length - 1] || 'ok'
+      if (!trimmed && orderedTypes[0]) {
         score = 0.9
-        type = errorTypes[0]
-      } else if (trimmed.length < 10 && errorTypes[1]) {
+        type = orderedTypes[0]
+      } else if (trimmed.length < 10 && orderedTypes[1]) {
         score = 0.8
-        type = errorTypes[1]
+        type = orderedTypes[1]
       } else {
         score = 0.2
       }


### PR DESCRIPTION
## Summary
- sort `errorTypes` alphabetically before predictions
- document sorting in the hooks guide
- note sorting in the README example

## Testing
- `npm --workspace packages/example run lint`
- `npm --workspace packages/example run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6884eddc7fc48330a6b0761655509f68