### PR TITLE
Improve training pipeline to use field/value pairs

### DIFF
--- a/packages/form-buddy/src/hooks/useFormBuddy.ts
+++ b/packages/form-buddy/src/hooks/useFormBuddy.ts
@@ -1,21 +1,21 @@
-import { useEffect, useRef, useState } from 'react'
-import { useFormContext, type FieldValues, type Path } from 'react-hook-form'
-import { loadModel, type Model, type Prediction } from '../lib/classifier'
-import { loadLLM, type LLM } from '../lib/llm'
-import type { SystemPromptGenerator } from '../prompts'
+import { useEffect, useRef, useState } from "react";
+import { useFormContext, type FieldValues, type Path } from "react-hook-form";
+import { loadModel, type Model, type Prediction } from "../lib/classifier";
+import { loadLLM, type LLM } from "../lib/llm";
+import type { SystemPromptGenerator } from "../prompts";
 
-const logIO = true || import.meta.env.VITE_LOG_MODEL_IO === 'true'
+const logIO = true || import.meta.env.VITE_LOG_MODEL_IO === "true";
 
 export interface FieldDetail {
-  name: string
-  description: string
+  name: string;
+  description: string;
 }
 
 export interface FormBuddyOptions {
-  validationModelName?: string
-  llmModelName?: string
-  threshold?: number
-  errorTypes?: string[]
+  validationModelName?: string;
+  llmModelName?: string;
+  threshold?: number;
+  errorTypes?: string[];
 }
 
 export function useFormBuddy<T extends FieldValues>(
@@ -24,93 +24,105 @@ export function useFormBuddy<T extends FieldValues>(
   getSystemPrompt: SystemPromptGenerator,
   options: FormBuddyOptions = {},
 ) {
-  const { setError } = useFormContext<T>()
+  const { setError } = useFormContext<T>();
   const {
     validationModelName,
     llmModelName: llmName,
     threshold = 0.7,
     errorTypes,
-  } = options
-  const [loading, setLoading] = useState(true)
-  const [checking, setChecking] = useState<Record<string, boolean>>({})
-  const [mlModelName, setMLModelName] = useState<string | null>(null)
-  const [llmModelName, setLLMModelName] = useState<string | null>(null)
-  const modelRef = useRef<Model | null>(null)
-  const llmRef = useRef<LLM | null>(null)
-  const cache = useRef(new Map<string, string>())
+  } = options;
+  const [loading, setLoading] = useState(true);
+  const [checking, setChecking] = useState<Record<string, boolean>>({});
+  const [mlModelName, setMLModelName] = useState<string | null>(null);
+  const [llmModelName, setLLMModelName] = useState<string | null>(null);
+  const modelRef = useRef<Model | null>(null);
+  const llmRef = useRef<LLM | null>(null);
+  const cache = useRef(new Map<string, string>());
   const fieldMap = useRef<Record<string, string>>(
     Object.fromEntries(fields.map((f) => [f.name, f.description])),
-  )
+  );
 
   useEffect(() => {
-    let canceled = false
-    Promise.all([loadModel(validationModelName, errorTypes), loadLLM(llmName)]).then(([model, llm]) => {
-      console.log(`[ML] Loaded model: ${model.modelName}, LLM: ${llm.modelName}`)
+    let canceled = false;
+    Promise.all([
+      loadModel(validationModelName, errorTypes),
+      loadLLM(llmName),
+    ]).then(([model, llm]) => {
+      console.log(
+        `[ML] Loaded model: ${model.modelName}, LLM: ${llm.modelName}`,
+      );
 
       if (!canceled) {
-        modelRef.current = model
-        llmRef.current = llm
-        setMLModelName(model.modelName)
-        setLLMModelName(llm.modelName)
-        setLoading(false)
+        modelRef.current = model;
+        llmRef.current = llm;
+        setMLModelName(model.modelName);
+        setLLMModelName(llm.modelName);
+        setLoading(false);
       }
-    })
+    });
     return () => {
-      canceled = true
-    }
-  }, [validationModelName, llmName, errorTypes])
+      canceled = true;
+    };
+  }, [validationModelName, llmName, errorTypes]);
 
   const handleBlur = async (name: Path<T>, value: string) => {
+    if (logIO)
+      console.log(`[ML] Handling blur for field "${name}" with value:`, value);
+    if (!modelRef.current || !llmRef.current) return;
 
+    if (logIO) console.log(`[ML] Starting check for field "${name}"...`);
+    setChecking((m) => ({ ...m, [name]: true }));
 
-    if(logIO) console.log(`[ML] Handling blur for field "${name}" with value:`, value)
-    if (!modelRef.current || !llmRef.current) return
-
-    if(logIO) console.log(`[ML] Starting check for field "${name}"...`)
-    setChecking((m) => ({ ...m, [name]: true }))
-
-    const key = `${name}|${value}`
-    const cached = cache.current.get(key)
+    const key = `${name}|${value}`;
+    const cached = cache.current.get(key);
 
     if (cached) {
-      if(logIO) console.log(`[ML] Using cached response for field "${name}":`, cached)
-      setError(name, { type: 'formbuddy', message: cached })
-      setChecking((m) => ({ ...m, [name]: false }))
-      return
+      if (logIO)
+        console.log(`[ML] Using cached response for field "${name}":`, cached);
+      setError(name, { type: "formbuddy", message: cached });
+      setChecking((m) => ({ ...m, [name]: false }));
+      return;
     }
 
-    if(logIO) console.log(`[ML] Predicting for field "${name}"...`)
-    const prediction: Prediction = modelRef.current.predict(value)
-    if(logIO) console.log(`[ML] Field "${name}" prediction:`, prediction)
-    
+    if (logIO) console.log(`[ML] Predicting for field "${name}"...`);
+    const prediction: Prediction = modelRef.current.predict(
+      name as string,
+      value,
+    );
+    if (logIO) console.log(`[ML] Field "${name}" prediction:`, prediction);
+
     if (prediction.score > threshold) {
-      if(logIO) console.log(`[ML] Field "${name}" prediction above threshold:`, prediction)
-      
-      const fieldDesc = fieldMap.current[name] || ''
-      const text = `${value}\n\nForm: ${formDescription}\nField: ${fieldDesc}`
+      if (logIO)
+        console.log(
+          `[ML] Field "${name}" prediction above threshold:`,
+          prediction,
+        );
+
+      const fieldDesc = fieldMap.current[name] || "";
+      const text = `${value}\n\nForm: ${formDescription}\nField: ${fieldDesc}`;
       const systemPrompt = getSystemPrompt(
         formDescription,
         fieldDesc,
         prediction.type,
-      )
-      
+      );
+
       const prompt = `${text}${
-        prediction.type ? `\n\nReason: ${prediction.type}` : ''
-      }`
+        prediction.type ? `\n\nReason: ${prediction.type}` : ""
+      }`;
 
-      if(logIO) console.log(`Prompt for LLM:`, prompt);
-      if(logIO) console.log(`System prompt:`, systemPrompt);
+      if (logIO) console.log(`Prompt for LLM:`, prompt);
+      if (logIO) console.log(`System prompt:`, systemPrompt);
 
-      const message = await llmRef.current.explain(prompt, systemPrompt)
-      if(logIO) console.log(`LLM response for field "${name}":`, message);
+      const message = await llmRef.current.explain(prompt, systemPrompt);
+      if (logIO) console.log(`LLM response for field "${name}":`, message);
 
       if (message) {
-        cache.current.set(key, message)
-        setError(name, { type: 'formbuddy', message })
+        cache.current.set(key, message);
+        setError(name, { type: "formbuddy", message });
       }
     }
-    setChecking((m) => ({ ...m, [name]: false }))
-  }
+    setChecking((m) => ({ ...m, [name]: false }));
+  };
 
   return {
     handleBlur,
@@ -118,5 +130,5 @@ export function useFormBuddy<T extends FieldValues>(
     checking,
     mlModelName,
     llmModelName,
-  }
+  };
 }

--- a/training/requirements.txt
+++ b/training/requirements.txt
@@ -3,3 +3,4 @@ onnx
 skl2onnx
 packaging
 Faker
+pandas

--- a/training/tests/test_training_pipeline.py
+++ b/training/tests/test_training_pipeline.py
@@ -1,4 +1,3 @@
-import sys
 import importlib.util
 from pathlib import Path
 
@@ -30,12 +29,18 @@ def test_model_predictions():
 
     # generate dataset and train model in-memory
     gen.main()
-    texts, labels = trainer.load_data()
-    model = trainer.train_model(texts, labels)
+    records, labels = trainer.load_data()
+    model = trainer.train_model(records, labels)
 
     # verify classifier identifies vague or invalid inputs
-    pred_vague = model.predict(["stepsToReproduce: can't explain"])[0]
-    pred_invalid = model.predict(["appVersion: ver42"])[0]
+    import pandas as pd
+
+    pred_vague = model.predict(
+        pd.DataFrame([{"field": "stepsToReproduce", "value": "can't explain"}])
+    )[0]
+    pred_invalid = model.predict(
+        pd.DataFrame([{"field": "appVersion", "value": "ver42"}])
+    )[0]
 
     assert pred_vague == "vague"
     assert pred_invalid == "invalid"


### PR DESCRIPTION
## Summary
- modify training data structure to handle `field` and `value` separately
- update training pipeline to vectorize both fields and values
- adjust ONNX export for two-input model
- change JS classifier and hook to call `predict(field, value)`
- update tests accordingly and add pandas to requirements

## Testing
- `pip install -r training/requirements.txt`
- `pytest -q training/tests/test_training_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6885b6fff2f08330ac07d1af621ac167