### PR TITLE
Skip LLM when classifier label ok

### DIFF
--- a/packages/form-buddy/dist/hooks/useFormBuddy.js
+++ b/packages/form-buddy/dist/hooks/useFormBuddy.js
@@ -55,7 +55,7 @@ export function useFormBuddy(formDescription, fields, getSystemPrompt, options =
         const prediction = await modelRef.current.predict(name, value);
         if (logIO)
             console.log(`[ML] Field "${name}" prediction:`, prediction);
-        if (prediction.score > threshold) {
+        if (prediction.score > threshold && prediction.type !== 'ok') {
             if (logIO)
                 console.log(`[ML] Field "${name}" prediction above threshold:`, prediction);
             const fieldDesc = fieldMap.current[name] || "";

--- a/packages/form-buddy/src/useFormBuddy.js
+++ b/packages/form-buddy/src/useFormBuddy.js
@@ -95,7 +95,7 @@ export function useFormBuddy(
     const prediction = await modelRef.current.predict(name, value);
     logger(`Prediction for field ${name}:`, prediction);
 
-    if (prediction.score > threshold) {
+    if (prediction.score > threshold && prediction.type !== 'ok') {
       const fieldDesc = fieldMap.current[name] || "";
       const text = `${value}\n\nForm: ${formDescription}\nField: ${fieldDesc}`;
       const systemPrompt = getSystemPrompt(formDescription, fieldDesc, prediction.type);


### PR DESCRIPTION
## Summary
- avoid calling LLM when classifier predicts `ok`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ef0df53c833087d3d87951534941