### PR TITLE
Fix preprocessing in JS classifier

### DIFF
--- a/packages/form-buddy/src/lib/classifier.js
+++ b/packages/form-buddy/src/lib/classifier.js
@@ -4,13 +4,23 @@ import { logger } from './logger.js';
 // Simple in-memory cache for ONNX sessions by model name
 const modelSessionCache = new Map();
 
+function preprocess(field, value) {
+  let v = value;
+  if (v === '') v = '<EMPTY>';
+  if (field === 'fullName' && /\d/.test(v)) {
+    v += ' <HAS_DIGIT>';
+  }
+  return v;
+}
+
 function makePredict(session, orderedTypes) {
   return async function predict(field, value) {
 
     logger('predict called', { field, value });
+    const preValue = preprocess(field, value);
     const feeds = {
       field: new ort.Tensor('string', [field], [1, 1]),
-      value: new ort.Tensor('string', [value], [1, 1]),
+      value: new ort.Tensor('string', [preValue], [1, 1]),
     };
 
     const results = await session.run(feeds);


### PR DESCRIPTION
## Summary
- add `<EMPTY>` and `<HAS_DIGIT>` preprocessing logic for ONNX classifier in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68860007dc34833081d3452d056490be