### PR TITLE
Add browser-side model tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ npm --workspace packages/example run start
 
 Open `http://localhost:5173` to try it out.
 
+To verify the ONNX model directly in the browser, open your developer tools and
+run:
+
+```js
+await runModelTests()
+```
+
+Each predefined case will print `✅` or `❌` along with a summary so you can
+confirm the classifier behaves the same as the Python tests.
+
 ## Project Structure
 
 This repo uses **npm workspaces**.

--- a/packages/example/src/index.js
+++ b/packages/example/src/index.js
@@ -4,6 +4,7 @@ import { CssBaseline, ThemeProvider, createTheme } from '@mui/material'
 
 import './index.css';
 import App from './App';
+import { runModelTests } from './runModelTests';
 
 const theme = createTheme({
   palette: {
@@ -20,3 +21,8 @@ root.render(
     </ThemeProvider>
   </React.StrictMode>
 );
+
+// expose test helper on window for manual execution
+if (typeof window !== 'undefined') {
+  window.runModelTests = runModelTests;
+}

--- a/packages/example/src/runModelTests.js
+++ b/packages/example/src/runModelTests.js
@@ -1,0 +1,51 @@
+import { loadModel } from 'form-buddy/src/lib/classifier.js';
+
+const TEST_CASES = [
+  ['fullName', 'John Doe', 'ok'],
+  ['fullName', 'foo123', 'invalid'],
+  ['email', 'john@example.com', 'ok'],
+  ['email', 'user.com', 'invalid'],
+  ['email', '', 'missing'],
+  ['appVersion', 'v2.1.3', 'ok'],
+  ['appVersion', 'ver42', 'invalid'],
+  [
+    'stepsToReproduce',
+    'On Android 13, when I open the settings page, the app crashes with error code 500.',
+    'ok',
+  ],
+  ['stepsToReproduce', 'app crashed', 'vague'],
+  ['stepsToReproduce', '', 'missing'],
+  ['expectedBehavior', 'The app should work without errors.', 'ok'],
+  ['expectedBehavior', 'foo bar baz', 'vague'],
+  ['expectedBehavior', '', 'missing'],
+  ['actualBehavior', 'Instead, it shows a blank screen.', 'ok'],
+  ['actualBehavior', 'foo bar', 'vague'],
+  ['actualBehavior', '', 'missing'],
+];
+
+export async function runModelTests() {
+  const { predict } = await loadModel('bug_report_classifier.onnx', [
+    'invalid',
+    'missing',
+    'vague',
+    'ok',
+  ]);
+  let passed = 0;
+  for (const [field, value, expected] of TEST_CASES) {
+    const { type } = await predict(field, value);
+    const ok = type === expected;
+    const msg = `${field}: "${value}" => ${type}`;
+    if (ok) {
+      console.log('✅', msg);
+      passed++;
+    } else {
+      console.error('❌', msg, `(expected ${expected})`);
+    }
+  }
+  console.log(`Model tests: ${passed}/${TEST_CASES.length} passed`);
+}
+
+// Expose for manual usage in the browser console
+if (typeof window !== 'undefined') {
+  window.runModelTests = runModelTests;
+}


### PR DESCRIPTION
## Summary
- add a helper script to run model predictions in the browser
- expose `runModelTests` through the example app
- document how to run the tests from the dev console

## Testing
- `pytest tests/test_model.py::test_model_predictions -q`
- `CI=true npm --workspace packages/example test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688601baa0b08330888d6f2c83cfa6a5